### PR TITLE
Adding OnBackPressed Functionality

### DIFF
--- a/app/src/main/java/rocks/poopjournal/todont/About.java
+++ b/app/src/main/java/rocks/poopjournal/todont/About.java
@@ -167,4 +167,11 @@ public class About extends AppCompatActivity {
     }
 
 
+    @Override
+    public void onBackPressed() {
+        Intent i = new Intent(About.this, Settings.class);
+        finishAffinity();
+        startActivity(i);
+        overridePendingTransition(R.anim.fade_in, R.anim.fade_out);
+    }
 }

--- a/app/src/main/java/rocks/poopjournal/todont/Labels.java
+++ b/app/src/main/java/rocks/poopjournal/todont/Labels.java
@@ -168,4 +168,10 @@ public class Labels extends AppCompatActivity {
         Intent i = new Intent(this, MainActivity.class);
         startActivity(i);
     }
+
+    @Override
+    public void onBackPressed() {
+        Intent i = new Intent(this, MainActivity.class);
+        startActivity(i);
+    }
 }

--- a/app/src/main/java/rocks/poopjournal/todont/MainActivity.kt
+++ b/app/src/main/java/rocks/poopjournal/todont/MainActivity.kt
@@ -86,5 +86,9 @@ class MainActivity : AppCompatActivity() {
 
     }
 
+    override fun onBackPressed() {
+        finish()
+    }
+
 }
 

--- a/app/src/main/java/rocks/poopjournal/todont/Settings.java
+++ b/app/src/main/java/rocks/poopjournal/todont/Settings.java
@@ -170,4 +170,12 @@ public class Settings extends AppCompatActivity {
         startActivity(i);
         overridePendingTransition(R.anim.fade_in, R.anim.fade_out);
     }
+
+    @Override
+    public void onBackPressed() {
+        Intent i = new Intent(Settings.this, MainActivity.class);
+        finishAffinity();
+        startActivity(i);
+        overridePendingTransition(R.anim.fade_in, R.anim.fade_out);
+    }
 }


### PR DESCRIPTION
Adding the onbackpressed function to return to the previous activity whenever the back button is pressed rather than closing the app.
This works with the top right button but it's necessary to add this to the android bottom navigation back button as that is used most of the time.
There are multiple times when backpressed doesn't work the way it's intended to like for example, when you press the back button after adding a label it often goes back to the label add dialog, or when you click back from about or settings page where it directly closes the app and you also face this when the user installs it the first time and presses back from mainactivity or labels page where he is redirected to the onboarding page which shouldn't happen.

https://user-images.githubusercontent.com/73274558/193765173-b1c0505a-514c-40bc-bc6b-41dad3c69338.mp4

