### PR TITLE
Solving the single quote bug for both labels and note + selected label in the spinner

### DIFF
--- a/app/src/main/java/rocks/poopjournal/todont/Adapters/AvoidedAdapter.java
+++ b/app/src/main/java/rocks/poopjournal/todont/Adapters/AvoidedAdapter.java
@@ -95,9 +95,15 @@ public class AvoidedAdapter extends RecyclerView.Adapter<AvoidedAdapter.Recycler
                     spinner.setVisibility(View.VISIBLE);
                 }
                 habit.setText("" + Helper.data.get(position)[2]);
-                detail.setText("" + Helper.data.get(position)[3]);
+                detail.setText("" + Helper.habitsdata.get(position)[3].replace("''","'"));
+
+                ArrayList<String> reformed_labels = new ArrayList<>();
+                for (int i=0;i<Helper.labels_array.size();i++){
+                    reformed_labels.add(Helper.labels_array.get(i).toString().replace("''","'"));
+                }
+
                 final Adapter adapter = new ArrayAdapter<String>(con, android.R.layout.simple_list_item_1,
-                      Helper.labels_array) {
+                      reformed_labels) {
                     @Override
                     public boolean isEnabled(int position) {
                         return position != 0;
@@ -106,7 +112,7 @@ public class AvoidedAdapter extends RecyclerView.Adapter<AvoidedAdapter.Recycler
                 spinner.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
                     @Override
                     public void onItemSelected(AdapterView<?> adapterView, View view, int i, long l) {
-                        catagoryselected = adapterView.getItemAtPosition(i).toString();
+                        catagoryselected = adapterView.getItemAtPosition(i).toString().replace("'","''");
                         TextView selectedText = (TextView) adapterView.getChildAt(i);
                         if (selectedText != null) {
                             selectedText.setTextColor(ContextCompat.getColor(con,R.color.g2));
@@ -131,7 +137,8 @@ public class AvoidedAdapter extends RecyclerView.Adapter<AvoidedAdapter.Recycler
                         } catch (SQLiteException e) {
                         }
                         Log.d("checkingz",""+habit.getText().toString());
-                        db.update_data(position, formattedDate,habit.getText().toString(), detail.getText().toString(), catagoryselected);
+                        db.update_habitsdata(position, formattedDate,habit_text
+                                , detail.getText().toString().replace("'","''"), catagoryselected);
                         db.show_data();
                         Helper.SelectedButtonOfTodayTab = 1;
                         Intent intent = new Intent(con, MainActivity.class);
@@ -141,7 +148,7 @@ public class AvoidedAdapter extends RecyclerView.Adapter<AvoidedAdapter.Recycler
                     }
 
                 });
-                  spinner.setAdapter((SpinnerAdapter) adapter);
+                spinner.setAdapter((SpinnerAdapter) adapter);
                 bottomSheetDialog.setContentView(bottomsheetview);
                 bottomSheetDialog.show();
             }

--- a/app/src/main/java/rocks/poopjournal/todont/Adapters/DoneAdapter.java
+++ b/app/src/main/java/rocks/poopjournal/todont/Adapters/DoneAdapter.java
@@ -93,9 +93,15 @@ public class DoneAdapter extends RecyclerView.Adapter<DoneAdapter.RecyclerViewHo
                     spinner.setVisibility(View.VISIBLE);
                 }
                 habit.setText("" + Helper.donedata.get(position)[2]);
-                detail.setText("" + Helper.donedata.get(position)[3]);
+                detail.setText("" + Helper.habitsdata.get(position)[3].replace("''","'"));
+
+                ArrayList<String> reformed_labels = new ArrayList<>();
+                for (int i=0;i<Helper.labels_array.size();i++){
+                    reformed_labels.add(Helper.labels_array.get(i).toString().replace("''","'"));
+                }
+
                 final Adapter adapter = new ArrayAdapter<String>(con, android.R.layout.simple_list_item_1,
-                        Helper.labels_array) {
+                        reformed_labels) {
                     @Override
                     public boolean isEnabled(int position) {
                         return position != 0;
@@ -105,7 +111,7 @@ public class DoneAdapter extends RecyclerView.Adapter<DoneAdapter.RecyclerViewHo
                 spinner.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
                     @Override
                     public void onItemSelected(AdapterView<?> adapterView, View view, int i, long l) {
-                        catagoryselected = adapterView.getItemAtPosition(i).toString();
+                        catagoryselected = adapterView.getItemAtPosition(i).toString().replace("'","''");
                         TextView selectedText = (TextView) adapterView.getChildAt(i);
                         if (selectedText != null) {
                             selectedText.setTextColor(ContextCompat.getColor(con,R.color.g2));
@@ -127,7 +133,8 @@ public class DoneAdapter extends RecyclerView.Adapter<DoneAdapter.RecyclerViewHo
 
                         } catch (SQLiteException e) {
                         }
-                        db.update_done_data(position,formattedDate, habit_text, detail_text, catagoryselected);
+                        db.update_habitsdata(position, formattedDate,habit_text
+                                , detail.getText().toString().replace("'","''"), catagoryselected);
                         db.show_data();
                         Intent intent = new Intent(con, MainActivity.class);
                         con.startActivity(intent);

--- a/app/src/main/java/rocks/poopjournal/todont/Adapters/HabitsAdapter.java
+++ b/app/src/main/java/rocks/poopjournal/todont/Adapters/HabitsAdapter.java
@@ -74,7 +74,7 @@ public class HabitsAdapter extends RecyclerView.Adapter<HabitsAdapter.RecyclerVi
     @Override
     public void onBindViewHolder(@NonNull final HabitsAdapter.RecyclerViewHolder holder, final int position) {
         String dTask = donotTask.get(position);
-        String dCatagory = donotCatagory.get(position);
+        String dCatagory = donotCatagory.get(position).replace("''","'");
         holder.task.setText(dTask);
         holder.catagoryoftask.setText(dCatagory);
         holder.task.setOnClickListener(new View.OnClickListener() {
@@ -98,9 +98,15 @@ public class HabitsAdapter extends RecyclerView.Adapter<HabitsAdapter.RecyclerVi
                     spinner.setVisibility(View.VISIBLE);
                 }
                 habit.setText("" + Helper.habitsdata.get(position)[2]);
-                detail.setText("" + Helper.habitsdata.get(position)[3]);
+                detail.setText("" + Helper.habitsdata.get(position)[3].replace("''","'"));
+
+                ArrayList<String> reformed_labels = new ArrayList<>();
+                for (int i=0;i<Helper.labels_array.size();i++){
+                    reformed_labels.add(Helper.labels_array.get(i).toString().replace("''","'"));
+                }
+
                 final Adapter adapter = new ArrayAdapter<String>(con, android.R.layout.simple_list_item_1,
-                        Helper.labels_array) {
+                        reformed_labels) {
                     @Override
                     public boolean isEnabled(int position) {
                         return position != 0;
@@ -110,7 +116,7 @@ public class HabitsAdapter extends RecyclerView.Adapter<HabitsAdapter.RecyclerVi
                 spinner.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
                     @Override
                     public void onItemSelected(AdapterView<?> adapterView, View view, int i, long l) {
-                        catagoryselected = adapterView.getItemAtPosition(i).toString();
+                        catagoryselected = adapterView.getItemAtPosition(i).toString().replace("'","''");
                         TextView selectedText = (TextView) adapterView.getChildAt(i);
                         if (selectedText != null) {
                             selectedText.setTextColor(ContextCompat.getColor(con, R.color.g2));
@@ -136,7 +142,7 @@ public class HabitsAdapter extends RecyclerView.Adapter<HabitsAdapter.RecyclerVi
                             Log.d("kuttistring",""+str);
                         }
                         db.update_habitsdata(position, formattedDate,str
-                                , detail.getText().toString(), catagoryselected);
+                                , detail.getText().toString().replace("'","''"), catagoryselected);
                         db.show_habits_data();
                         Intent intent = new Intent(con, MainActivity.class);
                         con.startActivity(intent);
@@ -147,6 +153,8 @@ public class HabitsAdapter extends RecyclerView.Adapter<HabitsAdapter.RecyclerVi
                 });
 
                 spinner.setAdapter((SpinnerAdapter) adapter);
+                spinner.setSelection(reformed_labels.indexOf(dCatagory));
+
                 bottomSheetDialog.setContentView(bottomsheetview);
                 bottomSheetDialog.show();
             }

--- a/app/src/main/java/rocks/poopjournal/todont/Fragments/LabelsAdapter.java
+++ b/app/src/main/java/rocks/poopjournal/todont/Fragments/LabelsAdapter.java
@@ -32,6 +32,8 @@ public class LabelsAdapter extends RecyclerView.Adapter<LabelsAdapter.RecyclerVi
         this.con = con;
         this.db=db;
 
+
+
     }
 
     @NonNull
@@ -45,7 +47,7 @@ public class LabelsAdapter extends RecyclerView.Adapter<LabelsAdapter.RecyclerVi
     @Override
     public void onBindViewHolder(@NonNull LabelsAdapter.RecyclerViewHolder holder, final int position) {
         final String dTask=labels_list.get(position);
-        holder.tv_label.setText(dTask);
+        holder.tv_label.setText(dTask.replace("''","'"));
         db.getNightMode();
         int count=db.countLabels(dTask);
         if(count>1){

--- a/app/src/main/java/rocks/poopjournal/todont/Labels.java
+++ b/app/src/main/java/rocks/poopjournal/todont/Labels.java
@@ -58,6 +58,7 @@ public class Labels extends AppCompatActivity {
         for (int i = 0; i < Helper.labels_array.size(); i++) {
             gettinglabels.add(Helper.labels_array.get(i));
         }
+
         rv_labels.setLayoutManager(new LinearLayoutManager(this));
         new ItemTouchHelper(itemtouchhelper).attachToRecyclerView(rv_labels);
         adapter= new LabelsAdapter(this,db,gettinglabels);
@@ -79,8 +80,9 @@ public class Labels extends AppCompatActivity {
                 btnsave.setOnClickListener(new View.OnClickListener() {
                     @Override
                     public void onClick(View view) {
-                        db.insert_label(editText.getText().toString());
-                        Helper.labels_array.add(editText.getText().toString());
+                        String entered_text = editText.getText().toString().replace("'","''");
+                        db.insert_label(entered_text);
+                        Helper.labels_array.add(entered_text);
                         db.show_labels();
                         Intent i = new Intent(getApplicationContext(), Labels.class);
                         startActivity(i);


### PR DESCRIPTION
The bug that is solved in this is mentioned in #66. 
This bug was instigated whenever there was a single quote ( ' ) present in the label or a note.
This was because SQLite considers a single quote as an endpoint for a string and that was the reason for it.
And I used continuous single quotes ('') replacing single quotes while adding and displaying which prevents it from crashing now because SQL exempts continuous single quotes.
It was done in all the page adapters.

I also upgraded the feature of the selected spinner of a habit which wasn't done before and it would select the first label rather than the label that is actually selected in the database.