### PR TITLE
bump gradle

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Fri Sep 06 00:28:53 BST 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
else
```
FAILURE: Build failed with an exception.

* Where:
Build file '/home/vagrant/build/rocks.poopjournal.todont/app/build.gradle' line: 2

* What went wrong:
An exception occurred applying plugin request [id: 'com.android.application']
> Failed to apply plugin 'com.android.internal.version-check'.
   > Minimum supported Gradle version is 8.9. Current version is 8.7. If using the gradle wrapper, try editing the distributionUrl in /home/vagrant/build/rocks.poopjournal.todont/gradle/wrapper/gradle-wrapper.properties to gradle-8.9-all.zip
```